### PR TITLE
Better integration with other python-related packages

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -90,7 +90,7 @@ class VirtualenvCommand(sublime_plugin.WindowCommand):
 
         if venv:
             project_data['virtualenv'] = venv
-            pyn = venv + '\\Scripts\\Python.exe'
+            pyn = os.path.join(venv, 'Scripts', 'Python')
             if not project_data.get('settings', None):
                 print('settings added for virtualenv')
                 project_data['settings'] = {'python_interpreter': pyn}

--- a/commands.py
+++ b/commands.py
@@ -90,10 +90,18 @@ class VirtualenvCommand(sublime_plugin.WindowCommand):
 
         if venv:
             project_data['virtualenv'] = venv
+            pyn = venv + '\\Scripts\\Python.exe'
+            if not project_data.get('settings', None):
+                print('settings added for virtualenv')
+                project_data['settings'] = {'python_interpreter': pyn}
+            else:
+                print('virtualenv added to settings')
+                project_data['settings']['python_interpreter'] = pyn
             sublime.status_message("({}) ACTIVATED".format(os.path.basename(venv)))
         else:
             try:
                 del project_data['virtualenv']
+                del project_data['settings']['python_interpreter']
                 sublime.status_message("DEACTIVATED")
             except KeyError:
                 pass

--- a/integrations.py
+++ b/integrations.py
@@ -23,23 +23,25 @@ class CurrentVirtualenvReplCommand(VirtualenvCommand):
             sublime.error_message(str(error) + " REPL cancelled!")
             return
 
+        self.repl_open(venv)
+
+    def repl_open(self, venv):
+        """Open a SublimeREPL using provided commands"""
         postactivate = virtualenv.activate(venv)
-
-        self.window.run_command('repl_open', {
-            'type': 'subprocess',
-            'autocomplete_server': True,
-
-            'cmd': ["python", "-u", "${packages}/SublimeREPL/config/Python/ipy_repl.py"],
-            'cwd': "$file_path",
-            'encoding': 'utf8',
-            'extend_env': dict({
-                'PATH': postactivate['path'],
-                'PYTHONIOENCODING': 'utf-8'
-            }, **postactivate['env']),
-
-            'syntax': "Packages/Python/Python.tmLanguage",
-            'external_id': "python"
-        })
+        self.window.run_command(
+            'repl_open', {
+                'encoding': 'utf8',
+                'type': 'subprocess',
+                'cmd': ["python", "-i", "-u"],
+                'cwd': '$file_path',
+                'extend_env': dict({
+                    'PATH': postactivate['path'],
+                    'PYTHONIOENCODING': 'utf-8'
+                }, **postactivate['env']),
+                'external_id': "venv_python",
+                'syntax': 'Packages/Python/Python.tmLanguage'
+            }
+        )
 
     def is_enabled(self):
         """If SublimeREPL is installed and a virtualenv is active."""


### PR DESCRIPTION
For commands.py:
    Anaconda and other python-related packages requires `python_interpreter` in project settings in order to work with virtual envs.

For integrations.py
    Because the `SublimeREPL` package does not support for newer version of `IPython`, so this does not call that no more.
